### PR TITLE
Only attempt to remove the attribute if it already exists during 389 Directory Server unlockPassword

### DIFF
--- a/src/main/java/com/novell/ldapchai/impl/directoryServer389/entry/DirectoryServer389User.java
+++ b/src/main/java/com/novell/ldapchai/impl/directoryServer389/entry/DirectoryServer389User.java
@@ -71,7 +71,15 @@ class DirectoryServer389User extends AbstractChaiUser implements ChaiUser {
     @Override
     public void unlockPassword() throws ChaiOperationException, ChaiUnavailableException {
         this.writeStringAttribute("passwordRetryCount", "0");
-        this.deleteAttribute("accountUnlockTime", null);    }
+        
+        // Only attempt to remove the attribute if it already
+        // exists to avoid exceptions trying to remove a
+        // non-existent attribute
+        final Date unlockDate = readDateAttribute("accountUnlockTime");
+        if (unlockDate != null) {
+           this.deleteAttribute("accountUnlockTime", null);
+        }
+    }
 
     @Override
     public boolean isPasswordLocked()


### PR DESCRIPTION
This is another attempt to send a proper pull request for this fix.  This fix is specific to the 389 Directory Server user unlockPassword function.  This change first checks that the accountUnlockTime attribute exists before attempting to remove it.  This avoids a fatal exception that can occur if the attribute does not exist when the deletion is attempted.