### PR TITLE
Ignoring Eclipse files, and fixing JDK 1.8 JavaDoc errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+/.classpath
+/.project
+/.settings

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
 						</goals>
 						<configuration>
 							<show>private</show>
+							<additionalparam>-Xdoclint:none</additionalparam>
 							<outputDirectory>${outputDirectory.private}/apidocs</outputDirectory>
 							<jarOutputDirectory>${outputDirectory.private}</jarOutputDirectory>
 							<attach>false</attach> <!-- requires using helper to attach with alternate classifier -->
@@ -232,6 +233,7 @@
 						</goals>
 						<configuration>
 							<show>public</show>
+							<additionalparam>-Xdoclint:none</additionalparam>
 							<excludePackageNames>com.novell.ldapchai.schema:com.novell.ldapchai.cr.nmasAuth:com.novell.ldapchai.util.internal:com.novell.ldapchai.impl.*</excludePackageNames>
 							<!-- <outputDirectory>${project.build.directory}/apidocs</outputDirectory>
 								default -->


### PR DESCRIPTION
Ignoring Eclipse project files (since these can be generated using the command: "mvn eclipse:eclipse"), and changed the JavaDoc generation to be less strict, since in JDK 1.8 doclint is used, which throws errors on any tags it considers not well-formed.

@jrivard Please review and merge.