### PR TITLE
Added three more checks for the use of NMAS APIs

### DIFF
--- a/src/main/java/com/novell/ldapchai/impl/edir/NmasCrFactory.java
+++ b/src/main/java/com/novell/ldapchai/impl/edir/NmasCrFactory.java
@@ -33,11 +33,13 @@ import com.novell.ldapchai.exception.ChaiUnavailableException;
 import com.novell.ldapchai.exception.ChaiValidationException;
 import com.novell.ldapchai.impl.edir.entry.NspmPasswordPolicy;
 import com.novell.ldapchai.provider.ChaiProvider;
+import com.novell.ldapchai.provider.ChaiSetting;
 import com.novell.ldapchai.util.ChaiLogger;
 import com.novell.ldapchai.util.StringHelper;
 import com.novell.security.nmas.jndi.ldap.ext.DeleteLoginConfigRequest;
 import com.novell.security.nmas.jndi.ldap.ext.DeleteLoginConfigResponse;
 import com.novell.security.nmas.mgmt.NMASChallengeResponse;
+
 import org.jdom2.JDOMException;
 
 import java.io.IOException;
@@ -179,6 +181,11 @@ public class NmasCrFactory {
 
     public static void clearResponseSet(final ChaiUser theUser)
             throws ChaiUnavailableException, ChaiOperationException {
+        final boolean useNmasSetting = theUser.getChaiProvider().getChaiConfiguration().getBooleanSetting(ChaiSetting.EDIRECTORY_ENABLE_NMAS);
+        if (!useNmasSetting) {
+            throw new UnsupportedOperationException("clearResponseSet() is not supported when ChaiSetting.EDIRECTORY_ENABLE_NMAS is false");
+        }
+
         final ChaiProvider provider = theUser.getChaiProvider();
 
         final DeleteLoginConfigRequest request = new DeleteLoginConfigRequest();

--- a/src/main/java/com/novell/ldapchai/impl/edir/NmasResponseSet.java
+++ b/src/main/java/com/novell/ldapchai/impl/edir/NmasResponseSet.java
@@ -26,10 +26,12 @@ import com.novell.ldapchai.cr.bean.ChallengeBean;
 import com.novell.ldapchai.exception.ChaiOperationException;
 import com.novell.ldapchai.exception.ChaiUnavailableException;
 import com.novell.ldapchai.exception.ChaiValidationException;
+import com.novell.ldapchai.provider.ChaiSetting;
 import com.novell.ldapchai.util.ChaiLogger;
 import com.novell.ldapchai.util.StringHelper;
 import com.novell.security.nmas.jndi.ldap.ext.*;
 import com.novell.security.nmas.mgmt.NMASChallengeResponse;
+
 import org.jdom2.*;
 import org.jdom2.filter.ElementFilter;
 import org.jdom2.input.SAXBuilder;
@@ -37,6 +39,7 @@ import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 
 import javax.naming.ldap.ExtendedResponse;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -129,6 +132,11 @@ public class NmasResponseSet extends AbstractResponseSet {
     )
             throws ChaiUnavailableException, ChaiValidationException
     {
+        final boolean useNmasSetting = theUser.getChaiProvider().getChaiConfiguration().getBooleanSetting(ChaiSetting.EDIRECTORY_ENABLE_NMAS);
+        if (!useNmasSetting) {
+            throw new UnsupportedOperationException("readNmasUserResponseSet() is not supported when ChaiSetting.EDIRECTORY_ENABLE_NMAS is false");
+        }
+
         final GetLoginConfigRequest request = new GetLoginConfigRequest();
         request.setObjectDN(theUser.getEntryDN());
         request.setTag("ChallengeResponseQuestions");
@@ -238,6 +246,11 @@ public class NmasResponseSet extends AbstractResponseSet {
     boolean write()
             throws ChaiUnavailableException, ChaiOperationException
     {
+        final boolean useNmasSetting = user.getChaiProvider().getChaiConfiguration().getBooleanSetting(ChaiSetting.EDIRECTORY_ENABLE_NMAS);
+        if (!useNmasSetting) {
+            throw new UnsupportedOperationException("write() is not supported when ChaiSetting.EDIRECTORY_ENABLE_NMAS is false");
+        }
+
         if (this.state != STATE.NEW) {
             throw new IllegalStateException("RepsonseSet not suitable for writing (not in NEW state)");
         }


### PR DESCRIPTION
Added three more checks for the use of NMAS APIs when EDIRECTORY_ENABLE_NMAS has not been set properly.

It should be obvious that EDIRECTORY_ENABLE_NMAS should be set to true when using Nmas* classes, but this check enforces the use of the flag when trying to use NMAS APIs.

@jrivard Please review and merge